### PR TITLE
perf: optimise process labels

### DIFF
--- a/src/nextflow.config
+++ b/src/nextflow.config
@@ -448,24 +448,19 @@ profiles {
 
 process {
 	//before memory = 80.GB and cpus = 40
-    memory = 20.GB
-    cpus = 10
+    memory = 5.GB
+    cpus = 1
+    time = "2h"
     
     withLabel: "gcc" {
-        memory = 5.GB
-        cpus = 1
         container = "gcc:latest"
     }
 
     withLabel: "bash" {
-        memory = 5.GB
-        cpus = 1
         container = "debian:stable-slim"
     }
 
     withLabel: "samtools" {
-        memory = 5.GB
-        cpus = 1
         // this converts from docker to singularity automatically by nextflow
         // original command is: docker pull zavolab/samtools:1.8
         // container = "docker://zavolab/samtools:1.8"
@@ -498,10 +493,12 @@ process {
     withLabel: "heavy_computation" {
         memory = 80.GB
         cpus = 20
+		time = "6h"
     }
 
     withLabel: "super_heavy_computation" {
         memory = 120.GB
         cpus = 40
+		time = "6h"
     }
 }

--- a/src/processes_advanced.nf
+++ b/src/processes_advanced.nf
@@ -1254,7 +1254,7 @@ process COMBINE_MOTIF_ORDERS{
 process COMPUTE_SCORES_FOR_MOTIF_ALTER{
 
 	label "custom_python"
-	label "heavy_computation"
+	label "heavy_memory"
 	publishDir "${params.folder_template}/result/${params.result_folder}/${specific_sample}/motif_freq_plot", mode: 'copy'
 
 	input:


### PR DESCRIPTION
I noticed that some processes request cpu cores that are not used. 
So I simplified and reduced the process requirements.
Specifically, each process uses by default 1 CPU, 5 GB memory and 2 hours of runtime. 

The only process I found that uses multiple cpus is `PERFORM_CLUSTERING_TUPLE`, which is labelled "heavy_computation". With the priority given to "withLabel" over the generic process configuration (see docs [here](https://www.nextflow.io/docs/latest/config.html#selector-priority)), this process is using multiple cpus. 
The process `COMBINE_MOTIF_ORDERS` does use a python script without specifying multiple cpus, so I changed it from "heavy_computation" to "heavy_memory", keeping the memory footprint the same. 